### PR TITLE
Add action: ActivateGameObjectChildByName

### DIFF
--- a/Assets/PlayMaker Custom Actions/GameObject/ActivateGameObjectChildByName.cs
+++ b/Assets/PlayMaker Custom Actions/GameObject/ActivateGameObjectChildByName.cs
@@ -59,17 +59,17 @@ namespace HutongGames.PlayMaker.Actions {
       }
     }
 
-    void DoActivateGameObject(bool reverse = false) {
+    void DoActivateGameObject() {
       var root = Fsm.GetOwnerDefaultTarget(gameObject);
 
       if (root == null) {
         return;
       }
 
-      DoActivateGameObject(root, reverse);
+      DoActivateGameObject(root);
     }
 
-    void DoActivateGameObject(GameObject node, bool reverse = false) {
+    void DoActivateGameObject(GameObject node) {
       if (node == null) {
         return;
       }
@@ -87,7 +87,7 @@ namespace HutongGames.PlayMaker.Actions {
             link.gameObject.SetActive(activate.Value);
           }
           if (recursive.Value) {
-            DoActivateGameObject(child.gameObject, activate.Value);
+            DoActivateGameObject(child.gameObject);
           }
         }
       }

--- a/Assets/PlayMaker Custom Actions/GameObject/ActivateGameObjectChildByName.cs
+++ b/Assets/PlayMaker Custom Actions/GameObject/ActivateGameObjectChildByName.cs
@@ -1,0 +1,96 @@
+// License: Attribution 4.0 International (CC BY 4.0)
+/*--- __ECO__ __PLAYMAKER__ __ACTION__ ---*/
+// Keywords: activate, gameobject, child, children
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace HutongGames.PlayMaker.Actions {
+  [ActionCategory(ActionCategory.GameObject)]
+  [Tooltip("Activates/deactivates one or more Game Object children by name. Use this to hide/show areas, or enable/disable many Behaviours at once. Optionally reverse the action on exit.")]
+  public class ActivateGameObjectChildByName : FsmStateAction {
+    [RequiredField]
+    [Tooltip("The parent GameObject.")]
+    public FsmOwnerDefault gameObject;
+    [Tooltip("Name(s) of children to activate/deactivate. Slashes may be used to denote heirarchical paths.")]
+    public FsmString[] names;
+    [RequiredField]
+    [Tooltip("Activate/deactivate the game object.")]
+    public FsmBool activate;
+    [Tooltip("Apply recursively to child objects.")]
+    public FsmBool recursive;
+    [Tooltip("Reverse activate action on exit.")]
+    public FsmBool resetOnExit;
+    [Tooltip("Repeat this action every frame. Useful if Activate changes over time.")]
+    public bool everyFrame;
+
+    // store the game object that we activated on enter
+    // so we can de-activate it on exit.
+    HashSet<GameObject> activatedGameObjects = new HashSet<GameObject>();
+    bool equal;
+
+    public override void Reset() {
+      gameObject = null;
+      names = new FsmString[1];
+      activate = false;
+      recursive = false;
+      everyFrame = false;
+      resetOnExit = false;
+    }
+
+    public override void OnEnter() {
+      activatedGameObjects.Clear();
+      DoActivateGameObject();
+
+      if (!everyFrame) {
+        Finish();
+      }
+    }
+
+    public override void OnUpdate() {
+      DoActivateGameObject();
+    }
+
+    public override void OnExit() {
+      if (!resetOnExit.Value) {
+        return;
+      }
+      foreach (var obj in activatedGameObjects) {
+        obj.SetActive(!activate.Value);
+      }
+    }
+
+    void DoActivateGameObject(bool reverse = false) {
+      var root = Fsm.GetOwnerDefaultTarget(gameObject);
+
+      if (root == null) {
+        return;
+      }
+
+      DoActivateGameObject(root, reverse);
+    }
+
+    void DoActivateGameObject(GameObject node, bool reverse = false) {
+      if (node == null) {
+        return;
+      }
+
+      foreach (var childName in names) {
+        var child = node.transform.Find(childName.Value);
+        if (child != null) {
+          activatedGameObjects.Add(child.gameObject);
+          child.gameObject.SetActive(activate.Value);
+          // If childName is a path/heirarchy, activate all intermediate nodes.
+          var link = child;
+          while (link.transform.parent != node.transform && link.transform.parent != null) {
+            link = link.parent;
+            activatedGameObjects.Add(link.gameObject);
+            link.gameObject.SetActive(activate.Value);
+          }
+          if (recursive.Value) {
+            DoActivateGameObject(child.gameObject, activate.Value);
+          }
+        }
+      }
+    }
+  }
+}

--- a/Assets/PlayMaker Custom Actions/GameObject/ActivateGameObjectChildByName.cs.meta
+++ b/Assets/PlayMaker Custom Actions/GameObject/ActivateGameObjectChildByName.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: ef3241716bbe44e90b0407ea0ba01f83
+timeCreated: 1494435124
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Adds an action similar to ActivateGameObjectChild, except it allows specifying the child[ren] by string names. The call can be recursive, looking for the child names at each level. It can also contain slashes to denote hierarchical paths.